### PR TITLE
Remove link to website and url_launcher

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,21 +1,15 @@
 PODS:
   - Flutter (1.0.0)
-  - url_launcher (0.0.1):
-    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Pods/.symlinks/flutter/ios`)
-  - url_launcher (from `Pods/.symlinks/plugins/url_launcher/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Pods/.symlinks/flutter/ios
-  url_launcher:
-    :path: Pods/.symlinks/plugins/url_launcher/ios
 
 SPEC CHECKSUMS:
   Flutter: 9d0fac939486c9aba2809b7982dfdbb47a7b0296
-  url_launcher: 92b89c1029a0373879933c21642958c874539095
 
 PODFILE CHECKSUM: ea0518673586564c605fb6593d385c0e3708ff8d
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -259,12 +259,10 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${PODS_ROOT}/.symlinks/flutter/ios/Flutter.framework",
-				"${BUILT_PRODUCTS_DIR}/url_launcher/url_launcher.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/lib/pages/appbar_builder.dart
+++ b/lib/pages/appbar_builder.dart
@@ -1,27 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:layout_demo_flutter/layout_type.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class AppBarBuilder {
-  static void _launchURL() async {
-    const url = 'https://codingwithflutter.com';
-    if (await canLaunch(url)) {
-      await launch(url);
-    } else {
-      throw 'Could not launch $url';
-    }
-  }
 
   static AppBar build({LayoutType layoutType, PreferredSize bottom}) {
     return AppBar(
       title: Text(layoutName(layoutType)),
       elevation: 1.0,
-      actions: [
-        IconButton(
-          icon: Icon(Icons.info_outline),
-          onPressed: _launchURL,
-        )
-      ],
       bottom: bottom,
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -331,13 +331,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.5"
-  url_launcher:
-    dependency: "direct main"
-    description:
-      name: url_launcher
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1"
   utf:
     dependency: transitive
     description:
@@ -375,4 +368,3 @@ packages:
     version: "2.1.13"
 sdks:
   dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.54.0.flutter-46ab040e58"
-  flutter: ">=0.1.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,6 @@ description: A new Flutter project.
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: 3.0.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Some users reported problems running the app with `url_launcher`.

Removing it as not really needed for the demo.