### PR TITLE
fix compile bug on hero page

### DIFF
--- a/lib/pages/hero_page.dart
+++ b/lib/pages/hero_page.dart
@@ -3,7 +3,7 @@ import 'package:layout_demo_flutter/layout_type.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/foundation.dart';
 
-class HeroHeader implements SliverPersistentHeaderDelegate {
+class HeroHeader extends SliverPersistentHeaderDelegate {
   HeroHeader({
     this.layoutGroup,
     this.onLayoutToggle,


### PR DESCRIPTION
Change `HeroHeader implements SliverPersistentHeaderDelegate` to `HeroHeader extends SliverPersistentHeaderDelegate` to fix missing implementation of stretchConfiguration method as it mentioned in this issue https://github.com/bizz84/layout-demo-flutter/issues/9